### PR TITLE
Add $_GET['format'] check

### DIFF
--- a/www/api.php
+++ b/www/api.php
@@ -34,7 +34,7 @@ if (isset($_GET['tz'])) {
 
        
        
-switch ($_GET['format']) {
+switch ($_GET['format'] ?? null) {
     case "xml":
         header("Content-Type: text/xml");
         print xmldata($data);


### PR DESCRIPTION
https://isitfullmoon.com/api.php currently produces the following warning without a format query parameter:

> **Warning:** Undefined array key "format" in **/var/app/www/api.php** on line **37**

The default format `json` is already handled by the `switch` `default`.